### PR TITLE
Avoid data race between threadIndex and addThread

### DIFF
--- a/profiler/profiler.cpp
+++ b/profiler/profiler.cpp
@@ -107,12 +107,9 @@ void Profiler::stepTime(const std::string& tag, const std::string& info, bool is
 Profiler::FuncTimer* Profiler::beginFunc(const std::string& func)
 {
     std::thread::id th = std::this_thread::get_id();
-    int idx = m_funcs.threadIndex(th);
+    int idx = m_funcs.addThread(th);
     if (idx == -1) {
-        idx = m_funcs.addThread(th);
-        if (idx == -1) {
-            return nullptr;
-        }
+        return nullptr;
     }
     size_t index = static_cast<size_t>(idx);
 


### PR DESCRIPTION
I have built MuseScore with the thread sanitizer.  One of the complaints issued by the thread sanitizer is that one thread called `Profiler::FuncsData::threadIndex` from `Profiler::beginFunc` without holding a lock while another thread was in `Profiler::FuncsData::addThread` while holding `this->mutex`.  The call to `threadIndex` from `beginFunc` is superfluous, since the first thing `addThread` does is call `threadIndex`.  Furthermore, the latter call is protected by a lock while the former is not.  This PR removes the former call to eliminate the race.